### PR TITLE
update hotfix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -149,7 +149,7 @@ app.on('ready', () => {
         dockerClient.dockerConnectionTest().then((res) => {
           if (res) {
             internetAvailable().then(() => {
-              checkForUpdates(this.uiManager, true);
+              checkForUpdates(uiManager, true);
             })
             .catch(() => {
               dialog.showMessageBox({


### PR DESCRIPTION
incorrectly referencing this.uiManager instead of uiManager caused internetAvailable to resolve to a catch even with a valid internet connection