### PR TITLE
Changed windows warning for closing docker

### DIFF
--- a/app/toolbar/components/status/states/confirm/Confirm.jsx
+++ b/app/toolbar/components/status/states/confirm/Confirm.jsx
@@ -136,13 +136,13 @@ class Confirm extends React.Component<Props> {
   confirmAction = confirm => {
     const { props, state } = this;
     const { category, storage, quittingApp } = props;
-    this.setState({ showQuitDocker: true });
     // TODO check config to see if setting is remembered
     const shouldCloseDockerConfig = removeWarning
       ? false
       : storage.get('close.dockerConfirm');
     const validateDockerClose = shouldCloseDockerConfig === undefined;
 
+    this.setState({ showQuitDocker: true });
     if (category === 'close.docker') {
       this.stopGigantumState();
       this.handleGigantumClose(confirm);

--- a/app/toolbar/components/status/states/confirm/Confirm.jsx
+++ b/app/toolbar/components/status/states/confirm/Confirm.jsx
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
-import utils from '../../../../../libs/utilities';
+// assets
+import quitDocker from 'Images/logos/quit-docker-windows.gif';
 // States
 import {
   CANCEL,
@@ -39,7 +40,8 @@ class Confirm extends React.Component<Props> {
   props: Props;
 
   state = {
-    isChecked: false
+    isChecked: false,
+    showQuitDocker: false
   };
 
   componentDidMount = () => {
@@ -134,6 +136,7 @@ class Confirm extends React.Component<Props> {
   confirmAction = confirm => {
     const { props, state } = this;
     const { category, storage, quittingApp } = props;
+    this.setState({ showQuitDocker: true });
     // TODO check config to see if setting is remembered
     const shouldCloseDockerConfig = removeWarning
       ? false
@@ -181,7 +184,7 @@ class Confirm extends React.Component<Props> {
         storage.set('hide.dockerWarning', true);
       }
       if (!confirm) {
-        utils.open('https://docs.gigantum.com/');
+        this.setState({ showQuitDocker: true });
       } else {
         props.transition(CONFIRM_WARNING, {
           message: 'Click to Start'
@@ -193,6 +196,7 @@ class Confirm extends React.Component<Props> {
   render() {
     const { props, state } = this;
     const { category } = props;
+    const { showQuitDocker } = state;
     let checkboxText =
       category === 'close.docker'
         ? 'Remember my selection next time'
@@ -202,6 +206,22 @@ class Confirm extends React.Component<Props> {
 
     const primaryText = category === 'warn.docker' ? 'Got it' : 'Yes';
     const secondaryText = category === 'warn.docker' ? 'Show me how' : 'No';
+
+    if (showQuitDocker) {
+      return (
+        <div className="Confirm__fixed">
+          <img alt="closeDocker" src={quitDocker} width="253" height="300" />
+          <button
+            type="button"
+            className="Btn__Confirm"
+            onClick={() => this.confirmAction(true)}
+          >
+            Got it
+          </button>
+        </div>
+      );
+    }
+
     return (
       <div className="Confirm">
         <div className="Confirm__message">{props.message}</div>

--- a/app/toolbar/components/status/states/confirm/Confirm.scss
+++ b/app/toolbar/components/status/states/confirm/Confirm.scss
@@ -1,16 +1,30 @@
 @import '~Styles/_imports.scss';
 
-.Confirm__container {
-  @include flex(space-between, column);
-  align-items: center;
-  padding: 20px;
-}
+.Confirm {
+  &__fixed {
+    position: fixed;
+    z-index: 1;
+    width: 100%;
+    height: 400px;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    flex-direction: column;
+    background: white;
+  }
 
-.Confirm__message {
-  font-size: 19px;
-  color: $primary;
-  text-align: center;
-  padding-top: 15px;
+  &__container {
+    @include flex(space-between, column);
+    align-items: center;
+    padding: 20px;
+  }
+
+  &__message {
+    font-size: 19px;
+    color: $primary;
+    text-align: center;
+    padding-top: 15px;
+  }
 }
 
 .Btn {

--- a/app/toolbar/components/status/states/running/Running.jsx
+++ b/app/toolbar/components/status/states/running/Running.jsx
@@ -56,7 +56,9 @@ class Running extends React.Component<Props> {
   */
   handleGigantumClose = closeDocker => {
     const { props } = this;
-    const hideWarning = props.storage.get('hide.dockerWarning');
+    const wslConfigured = props.storage.get('wslConfigured');
+    const hideWarning =
+      props.storage.get('hide.dockerWarning') || wslConfigured;
     const callback = response => {
       if (response.success) {
         if (isWindows && !hideWarning) {


### PR DESCRIPTION
- Removed warning to close docker if WSL is enabled
- 'Show me how' button will now display a gif showing how to close docker